### PR TITLE
docs: fix link to headless xvfb doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XVFB Github Action
 
-This action installs [XVFB](http://elementalselenium.com/tips/38-headless) and runs your headless tests with it. It cleans up the xvfb process after your tests are done. If it detects you're not using linux then your tests still run, but without xvfb, which is very practical for multi-platform workflows.
+This action installs [XVFB](https://elemental-selenium.herokuapp.com/tips/38-headless) and runs your headless tests with it. It cleans up the xvfb process after your tests are done. If it detects you're not using linux then your tests still run, but without xvfb, which is very practical for multi-platform workflows.
 
 ### Example usage
 


### PR DESCRIPTION
Noticed there was a PR open to fix a link in the readme https://github.com/coactions/setup-xvfb/pull/22, but I think the link in this PR might be the correct link.